### PR TITLE
make type consistent across files

### DIFF
--- a/FAQ/Im-Receiving-a-IP-dgm-len-alert.md
+++ b/FAQ/Im-Receiving-a-IP-dgm-len-alert.md
@@ -1,3 +1,5 @@
+## I'm receiving an error regarding IP Datagram length, what is the problem? ##
+
 If you are receiving an error message that looks like:
 
 `(snort_decoder) WARNING: IP dgm len > captured len`

--- a/FAQ/My-Snort-log-is-an-empty-file.md
+++ b/FAQ/My-Snort-log-is-an-empty-file.md
@@ -1,3 +1,5 @@
+## My Snort log is an empty file, what could be the cause? ##
+
 If a log in your Snort-log directory is an empty file like this:
 
 	-rw-------. 1 root  root     0 Sep 20 11:30 merged.log.1411187404

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -18,7 +18,7 @@
 
 [I'm not receiving alerts in Snort](https://github.com/vrtadmin/snort-faq/blob/master/FAQ/Im-not-receiving-alerts-in-Snort.md)
 
-[Is Snort going to incorporate <output plugin> in the near future?](https://github.com/vrtadmin/snort-faq/blob/master/FAQ/Snort-Output-Plugins.md)
+[Which Output Plugins will Snort incorporate in the near future?](https://github.com/vrtadmin/snort-faq/blob/master/FAQ/Snort-Output-Plugins.md)
 
 [I'm receiving an error regarding IP Datagram length, what is the problem?](https://github.com/vrtadmin/snort-faq/blob/master/FAQ/Im-Receiving-a-IP-dgm-len-alert.md)
 

--- a/FAQ/What-is-Open-Source.md
+++ b/FAQ/What-is-Open-Source.md
@@ -1,1 +1,3 @@
+## What is Open Source? ##
+
 The term open source typically refers to a program whose source code is released for use or modification by the community. Developers are free to download and make changes to the code as they please and create their own personalized product.

--- a/FAQ/What-is-a-Snort-Integrator.md
+++ b/FAQ/What-is-a-Snort-Integrator.md
@@ -1,1 +1,3 @@
+## What is a Snort Integrator? ##
+
 A Snort Integrator refers to any company that distributes Snort or Snort rules in their commercial offerings. This includes vendors bundling Snort or Snort rules, MSSPs and SIMs.

--- a/FAQ/What-is-the-relationship-between-Snort-and-Cisco.md
+++ b/FAQ/What-is-the-relationship-between-Snort-and-Cisco.md
@@ -1,1 +1,3 @@
+## What is the relationship between Snort and Cisco? ##
+
 Sourcefire was founded in 2001 by [Martin Roesch](http://en.wikipedia.org/wiki/Martin_Roesch), the original author of Snort, in response to demand for a commercial version of the popular technology. Sourcefire was acquired by Cisco Systems on October 7, 2013. Our mission is to combine our open source roots with proprietary innovation to deliver the most effective and comprehensive real-time network defense solutions on the planet. 

--- a/FAQ/What-is-the-role-of-Talos.md
+++ b/FAQ/What-is-the-role-of-Talos.md
@@ -1,3 +1,3 @@
-## What is the role of Talos ##
+## What is the role of Talos? ##
 
 Talos is a group of leading edge network security experts working to discover, assess, and respond to the latest trends in hacking activity, intrusion attempts, and vulnerabilities. This team is also supported by the vast resources of the open source Snort community, making it the largest group dedicated to advances in the network security industry.  The team authors the official Snort ruleset, the [Snort Subscriber Rule Set](https://www.snort.org/downloads/#rule-downloads) as well as all detection for [ClamAV](http://www.clamav.net) and [Razorback](http://labs.snort.org/razorback/).

--- a/FAQ/Where-can-I-download-Snort.md
+++ b/FAQ/Where-can-I-download-Snort.md
@@ -1,1 +1,3 @@
+## Where can I download Snort? ##
+
 You can download the latest Snort releases [here](http://www.snort.org/snort-downloads/). Snort rules can be downloaded [here](http://www.snort.org/snort-rules).


### PR DESCRIPTION
I'm addressing your request to have the Snort FAQ documents pulled directly from github and hosted on snort.org, like I did with clamav.net. I just added titles to the files that did not have them, and changed the title of the Snort Plugins link on README.md, since the "<" & ">" characters create problems. 
